### PR TITLE
to show the hint text

### DIFF
--- a/lib/screens/mobile_chat_screen.dart
+++ b/lib/screens/mobile_chat_screen.dart
@@ -46,6 +46,7 @@ class MobileChatScreen extends StatelessWidget {
               suffixIcon: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20.0),
                 child: Row(
+                  mainAxisSize: MainAxisSize.min,
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: const [
                     Icon(Icons.camera_alt, color: Colors.grey,),


### PR DESCRIPTION
Without defining the row size, the row is taking the whole space and the hint text is not visible.
To fix it, I added the mainAxisSize for the row.